### PR TITLE
Update to wrapper 15.3.4.2.

### DIFF
--- a/BDPointAndroidXamarinDemo/BDPointAndroidXamarinDemo.csproj
+++ b/BDPointAndroidXamarinDemo/BDPointAndroidXamarinDemo.csproj
@@ -107,7 +107,7 @@
       <Version>2.5.0.1</Version>
     </PackageReference>
     <PackageReference Include="Bluedot.PointSDK.Android">
-      <Version>15.3.4.1</Version>
+      <Version>15.3.4.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/BDPointAndroidXamarinDemo/BroadcastReceiver.cs
+++ b/BDPointAndroidXamarinDemo/BroadcastReceiver.cs
@@ -12,17 +12,33 @@ namespace BDPointAndroidXamarinDemo
     {
         public override void OnZoneEntryEvent(ZoneEntryEvent entryEvent, Context context)
         {
-            Toast.MakeText(context, "Received OnZoneEntryEvent "+entryEvent.ZoneInfo.ZoneName, ToastLength.Short).Show();
+            ZoneInfo zoneInfo = entryEvent.ZoneInfo;
+            string zoneData = "";
+            foreach(KeyValuePair<string, string> entry in zoneInfo.CustomData)
+            {
+                zoneData += $"{entry.Key}: {entry.Value}\n";
+            };
+
+            string entryText = $"Entered {zoneInfo.ZoneName}\n{zoneData}";
+            Toast.MakeText(context, entryText, ToastLength.Short).Show();
         }
 
         public override void OnZoneExitEvent(ZoneExitEvent exitEvent, Context context)
         {
-            Toast.MakeText(context, "Received OnZoneExitEvent", ToastLength.Short).Show();
+            ZoneInfo zoneInfo = exitEvent.ZoneInfo;
+            string zoneData = "";
+            foreach (KeyValuePair<string, string> entry in zoneInfo.CustomData)
+            {
+                zoneData += $"{entry.Key}: {entry.Value}\n";
+            };
+
+            string exitText = $"Left {zoneInfo.ZoneName}\n{zoneData}";
+            Toast.MakeText(context, exitText, ToastLength.Short).Show();
         }
 
         public override void OnZoneInfoUpdate(IList<ZoneInfo> zones, Context context)
         {
-            Toast.MakeText(context, "Received OnZoneInfoUpdate", ToastLength.Short).Show();
+            Toast.MakeText(context, "Received OnZoneInfoUpdate", ToastLength.Short).Show(); 
         }
     }
 

--- a/BDPointAndroidXamarinDemo/Properties/AndroidManifest.xml
+++ b/BDPointAndroidXamarinDemo/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.bluedot.point.xamarin_demo" android:versionName="15.3.4.1" android:versionCode="3">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.bluedot.point.xamarin_demo" android:versionName="15.3.4.2" android:versionCode="4">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
* Display zone custom data in entry and exit toasts.

**To test:** Trigger entry and/or exit events on zone with custom data, observe custom data in toasts.